### PR TITLE
imageserver: route image operations through runtime-aware ImageService

### DIFF
--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -115,7 +115,7 @@ func (c *ContainerServer) ContainerCheckpoint(
 	}
 
 	if !opts.KeepRunning {
-		if err := c.storageRuntimeServer.StopContainer(ctx, ctr.ID()); err != nil {
+		if err := c.storageRuntimeSvcMgr.GetRuntimeService().StopContainer(ctx, ctr.ID()); err != nil {
 			return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
 		}
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -318,7 +318,12 @@ func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Contain
 		return fmt.Errorf("error exporting root file-system diff for %q: %w", id, err)
 	}
 
-	mountPoint, err := c.ImageServiceMgr().GetImageService("").GetStore().Mount(id, specgen.Linux.MountLabel)
+	var runtimeHandler string
+	if img := ctr.CRIContainer().GetImage(); img != nil {
+		runtimeHandler = img.GetRuntimeHandler()
+	}
+
+	mountPoint, err := c.ImageServiceMgr().GetImageService(runtimeHandler).GetStore().Mount(id, specgen.Linux.MountLabel)
 	if err != nil {
 		return fmt.Errorf("not able to get mountpoint for container %q: %w", id, err)
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -318,7 +318,7 @@ func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Contain
 		return fmt.Errorf("error exporting root file-system diff for %q: %w", id, err)
 	}
 
-	mountPoint, err := c.ImageServiceMgr().GetImageService().GetStore().Mount(id, specgen.Linux.MountLabel)
+	mountPoint, err := c.ImageServiceMgr().GetImageService("").GetStore().Mount(id, specgen.Linux.MountLabel)
 	if err != nil {
 		return fmt.Errorf("not able to get mountpoint for container %q: %w", id, err)
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -318,7 +318,7 @@ func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Contain
 		return fmt.Errorf("error exporting root file-system diff for %q: %w", id, err)
 	}
 
-	mountPoint, err := c.StorageImageServer().GetStore().Mount(id, specgen.Linux.MountLabel)
+	mountPoint, err := c.ImageServiceMgr().GetImageService().GetStore().Mount(id, specgen.Linux.MountLabel)
 	if err != nil {
 		return fmt.Errorf("not able to get mountpoint for container %q: %w", id, err)
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -47,8 +47,8 @@ type ContainerServer struct {
 
 	runtime              *oci.Runtime
 	store                cstorage.Store
-	storageImageServer   storage.ImageServer
-	storageRuntimeServer storage.RuntimeServer
+	storageImgSvcMgr     *storage.ImageServiceManager
+	storageRuntimeSvcMgr *storage.RuntimeServiceManager
 	ctrNameIndex         *registrar.Registrar
 	ctrIDIndex           *truncindex.TruncIndex
 	podNameIndex         *registrar.Registrar
@@ -75,7 +75,7 @@ func (c *ContainerServer) Store() cstorage.Store {
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
 func (c *ContainerServer) StorageImageServer() storage.ImageServer {
-	return c.storageImageServer
+	return c.storageImgSvcMgr.GetImageService()
 }
 
 // CtrIDIndex returns the TruncIndex for the ContainerServer.
@@ -95,7 +95,7 @@ func (c *ContainerServer) Config() *libconfig.Config {
 
 // StorageRuntimeServer gets the runtime server for the ContainerServer.
 func (c *ContainerServer) StorageRuntimeServer() storage.RuntimeServer {
-	return c.storageRuntimeServer
+	return c.storageRuntimeSvcMgr.GetRuntimeService()
 }
 
 // New creates a new ContainerServer with options provided.
@@ -142,12 +142,12 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 		}
 	}
 
-	imageService, err := storage.GetImageService(ctx, store, nil, config)
+	storageImageServiceMgr, err := storage.GetImageServiceManager(ctx, store, nil, config)
 	if err != nil {
 		return nil, err
 	}
 
-	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, nil)
+	storageRuntimeServiceMgr := storage.GetRuntimeServiceManager(ctx, storageImageServiceMgr, nil)
 
 	runtime, err := oci.New(config)
 	if err != nil {
@@ -162,8 +162,8 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 	c := &ContainerServer{
 		runtime:              runtime,
 		store:                store,
-		storageImageServer:   imageService,
-		storageRuntimeServer: storageRuntimeService,
+		storageImgSvcMgr:     storageImageServiceMgr,
+		storageRuntimeSvcMgr: storageRuntimeServiceMgr,
 		ctrNameIndex:         registrar.NewRegistrar(),
 		ctrIDIndex:           truncindex.NewTruncIndex([]string{}),
 		podNameIndex:         registrar.NewRegistrar(),

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -73,9 +73,9 @@ func (c *ContainerServer) Store() cstorage.Store {
 	return c.store
 }
 
-// StorageImageServer returns the ImageServer for the ContainerServer.
-func (c *ContainerServer) StorageImageServer() storage.ImageServer {
-	return c.storageImgSvcMgr.GetImageService()
+// ImageServiceMgr returns the ImageServiceManager for the ContainerServer.
+func (c *ContainerServer) ImageServiceMgr() *storage.ImageServiceManager {
+	return c.storageImgSvcMgr
 }
 
 // CtrIDIndex returns the TruncIndex for the ContainerServer.

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -47,8 +47,11 @@ func (c *ContainerServer) ContainerRestore(
 	if err != nil {
 		return "", err
 	}
+
+	imageService := c.ImageServiceMgr().GetImageService()
+
 	// During checkpointing the container is unmounted. This mounts the container again.
-	mountPoint, err := c.StorageImageServer().GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)
+	mountPoint, err := imageService.GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)
 	if err != nil {
 		log.Debugf(ctx, "Failed to mount container %q: %v", ctr.ID(), err)
 
@@ -68,7 +71,7 @@ func (c *ContainerServer) ContainerRestore(
 		if ctr.RestoreStorageImageID() != nil {
 			log.Debugf(ctx, "Restoring from %v", ctr.RestoreStorageImageID())
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			imageMountPoint, err := c.StorageImageServer().GetStore().MountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), nil, "")
+			imageMountPoint, err := imageService.GetStore().MountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), nil, "")
 			if err != nil {
 				return "", err
 			}
@@ -77,7 +80,7 @@ func (c *ContainerServer) ContainerRestore(
 
 			defer func() {
 				// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-				_, err := c.StorageImageServer().GetStore().UnmountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), true)
+				_, err := imageService.GetStore().UnmountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), true)
 				if err != nil {
 					log.Errorf(ctx, "Failed to unmount checkpoint image: %q", err)
 				}

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -48,7 +48,12 @@ func (c *ContainerServer) ContainerRestore(
 		return "", err
 	}
 
-	imageService := c.ImageServiceMgr().GetImageService("")
+	sb, err := c.LookupSandbox(ctr.Sandbox())
+	if err != nil {
+		return "", err
+	}
+
+	imageService := c.ImageServiceMgr().GetImageService(sb.RuntimeHandler())
 
 	// During checkpointing the container is unmounted. This mounts the container again.
 	mountPoint, err := imageService.GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)
@@ -61,11 +66,6 @@ func (c *ContainerServer) ContainerRestore(
 	log.Debugf(ctx, "Container mountpoint %v", mountPoint)
 	log.Debugf(ctx, "Sandbox %v", ctr.Sandbox())
 	log.Debugf(ctx, "Specgen.Config.Annotations[io.kubernetes.cri-o.SandboxID] %v", ctrSpec.Config.Annotations["io.kubernetes.cri-o.SandboxID"])
-
-	sb, err := c.LookupSandbox(ctr.Sandbox())
-	if err != nil {
-		return "", err
-	}
 
 	if ctr.RestoreArchivePath() != "" || ctr.RestoreStorageImageID() != nil {
 		if ctr.RestoreStorageImageID() != nil {

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -48,7 +48,7 @@ func (c *ContainerServer) ContainerRestore(
 		return "", err
 	}
 
-	imageService := c.ImageServiceMgr().GetImageService()
+	imageService := c.ImageServiceMgr().GetImageService("")
 
 	// During checkpointing the container is unmounted. This mounts the container again.
 	mountPoint, err := imageService.GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)

--- a/internal/ociartifact/store.go
+++ b/internal/ociartifact/store.go
@@ -18,6 +18,7 @@ import (
 	libartStore "go.podman.io/common/pkg/libartifact/store"
 	libartTypes "go.podman.io/common/pkg/libartifact/types"
 	"go.podman.io/image/v5/docker/reference"
+	"go.podman.io/image/v5/image"
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/oci/layout"
 	"go.podman.io/image/v5/pkg/blobinfocache"
@@ -420,4 +421,63 @@ func artifactName(annotations map[string]string) string {
 	}
 
 	return ""
+}
+
+// PullConfig returns the pull an image configuration defined by the manifest digest.
+// There is no such config attached to OCI artifacts, but this function can
+// be used to retrieve an image's config without pulling the whole data.
+// This is useful for our support of runtimes that manage image pulls on thir own:
+// cri-o still needs to get the config, but should not pull the data layers.
+func (s *Store) PullConfig(ctx context.Context, nameOrDigest string, opts *PullOptions) (*specs.Image, error) {
+	artifact, nameIsDigest, err := s.getByNameOrDigest(ctx, nameOrDigest)
+	if err != nil {
+		return nil, fmt.Errorf("get artifact by name or digest: %w", err)
+	}
+
+	if nameIsDigest {
+		nameOrDigest = artifact.Reference()
+	}
+
+	// get the ImageSource for the image
+	imageReference, err := s.impl.LayoutNewReference(s.rootPath, nameOrDigest)
+	if err != nil {
+		return nil, fmt.Errorf("create new reference: %w", err)
+	}
+
+	imageSource, err := s.impl.NewImageSource(ctx, imageReference, s.SystemContext())
+	if err != nil {
+		return nil, fmt.Errorf("build image source: %w", err)
+	}
+	defer func() {
+		if err := s.impl.CloseImageSource(imageSource); err != nil {
+			log.Warnf(ctx, "Unable to close image source: %v", err)
+		}
+	}()
+
+	unparsedToplevel := image.UnparsedInstance(imageSource, nil)
+	topManifest, topMIMEType, err := unparsedToplevel.Manifest(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest: %w", err)
+	}
+
+	unparsedInstance := unparsedToplevel
+	if manifest.MIMETypeIsMultiImage(topMIMEType) {
+		// This is a manifest list. We need to choose a single instance to work with.
+		manifestList, err := manifest.ListFromBlob(topManifest, topMIMEType)
+		if err != nil {
+			return nil, fmt.Errorf("parsing primary manifest as list: %w", err)
+		}
+		instanceDigest, err := manifestList.ChooseInstance(s.SystemContext())
+		if err != nil {
+			return nil, fmt.Errorf("choosing an image from manifest list: %w", err)
+		}
+
+		unparsedInstance = image.UnparsedInstance(imageSource, &instanceDigest)
+	}
+
+	sourcedImage, err := image.FromUnparsedImage(ctx, s.SystemContext(), unparsedInstance)
+	if err != nil {
+		return nil, fmt.Errorf("getting sourced image from unparsed image: %w", err)
+	}
+	return sourcedImage.OCIConfig(ctx)
 }

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -28,7 +28,7 @@ func (i *ImageServiceManager) GetImageService(runtimeHandler string) ImageServer
 	if isRuntimePullImage {
 		return i.imageServiceVM
 	}
-	return i.imageService
+	return i.imageServiceVM
 }
 
 func GetImageServiceManager(ctx context.Context, store storage.Store, storageTransport StorageTransport, serverConfig *config.Config) (*ImageServiceManager, error) {
@@ -37,7 +37,7 @@ func GetImageServiceManager(ctx context.Context, store storage.Store, storageTra
 		return nil, err
 	}
 
-	is_vm := GetImageServiceVM(ctx, is)
+	is_vm := GetImageServiceVM(ctx, is.(*imageService))
 
 	return &ImageServiceManager{
 		serverConfig:   serverConfig,

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -1,0 +1,31 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/pkg/config"
+	"go.podman.io/storage"
+)
+
+// The ImageServiceManager object is responsible for maintaining different
+// implementations of the ImageServer interface.
+// It allows for easy switching between different image storage backends
+// depending on the configuration or environment.
+type ImageServiceManager struct {
+	imageService *imageService
+}
+
+func (i *ImageServiceManager) GetImageService() ImageServer {
+	return i.imageService
+}
+
+func GetImageServiceManager(ctx context.Context, store storage.Store, storageTransport StorageTransport, serverConfig *config.Config) (*ImageServiceManager, error) {
+	is, err := GetImageService(ctx, store, storageTransport, serverConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ImageServiceManager{
+		imageService: is.(*imageService),
+	}, nil
+}

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -12,11 +12,22 @@ import (
 // It allows for easy switching between different image storage backends
 // depending on the configuration or environment.
 type ImageServiceManager struct {
-	serverConfig *config.Config
-	imageService *imageService
+	serverConfig   *config.Config
+	imageService   *imageService
+	imageServiceVM *imageServiceVM
 }
 
-func (i *ImageServiceManager) GetImageService() ImageServer {
+func (i *ImageServiceManager) GetImageService(runtimeHandler string) ImageServer {
+	isRuntimePullImage := false
+	if runtimeHandler != "" {
+		r, ok := i.serverConfig.Runtimes[runtimeHandler]
+		if ok {
+			isRuntimePullImage = r.RuntimePullImage
+		}
+	}
+	if isRuntimePullImage {
+		return i.imageServiceVM
+	}
 	return i.imageService
 }
 
@@ -26,8 +37,11 @@ func GetImageServiceManager(ctx context.Context, store storage.Store, storageTra
 		return nil, err
 	}
 
+	is_vm := GetImageServiceVM(ctx, is)
+
 	return &ImageServiceManager{
-		serverConfig: serverConfig,
-		imageService: is.(*imageService),
+		serverConfig:   serverConfig,
+		imageService:   is.(*imageService),
+		imageServiceVM: is_vm.(*imageServiceVM),
 	}, nil
 }

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -12,6 +12,7 @@ import (
 // It allows for easy switching between different image storage backends
 // depending on the configuration or environment.
 type ImageServiceManager struct {
+	serverConfig *config.Config
 	imageService *imageService
 }
 
@@ -26,6 +27,7 @@ func GetImageServiceManager(ctx context.Context, store storage.Store, storageTra
 	}
 
 	return &ImageServiceManager{
+		serverConfig: serverConfig,
 		imageService: is.(*imageService),
 	}, nil
 }

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/ociartifact"
 	"github.com/cri-o/cri-o/internal/storage/references"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/common/libimage"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/types"
@@ -125,6 +126,12 @@ func (i *imageServiceVM) PullImage(ctx context.Context, imageName RegistryImageR
 	// create the StorageImageID from the manifest digest
 	ID := newExactStorageImageID(artifactManifestDigest.Encoded())
 
+	// Get the OCIConfig
+	ociConfig, err := artifactStore.PullConfig(ctx, artifactManifestDigest.Encoded(), &ociartifact.PullOptions{})
+	if err != nil {
+		return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: pull config err: %w", err)
+	}
+
 	// Generate an ImageResult with the available information, so that it can be
 	// returned by ImageStatus when asked with the same reference.
 	// Note that this structure is incomplete, since we're not actually pulling
@@ -144,13 +151,13 @@ func (i *imageServiceVM) PullImage(ctx context.Context, imageName RegistryImageR
 		RepoTags:            repoTags,
 		RepoDigests:         repoDigests,
 		Digest:              *artifactManifestDigest,
+		OCIConfig:           ociConfig,
 		// Following fields are not available at this stage, and will be left
 		// emty, or with default value
 		Size:         nil,
 		User:         "",
 		PreviousName: "",
 		Labels:       nil,
-		OCIConfig:    nil,
 		Annotations:  nil,
 		Pinned:       false,
 		MountPoint:   "",
@@ -259,4 +266,22 @@ func (i *imageServiceVM) IsRunningImageAllowed(ctx context.Context, systemContex
 	log.Debugf(i.ctx, "ImageServiceVM.IsRunningImageAllowed() start")
 	defer log.Debugf(i.ctx, "ImageServiceVM.IsRunningImageAllowed() end")
 	return i.storageImageServer.IsRunningImageAllowed(ctx, systemContext, userSpecifiedImage, imageID)
+}
+
+// GetConfigForImage returns the OCI config for the given image reference.
+//
+// The config is retrieved as part of the PullImage process, and stored in our
+// in-memory list of known images, so that it can be returned here without
+// pulling anything.
+func (i *imageServiceVM) GetConfigForImage(ctx context.Context, imageName string) (*v1.Image, error) {
+	log.Debugf(i.ctx, "ImageServiceVM.GetConfigForImage() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.GetConfigForImage() end")
+
+	for index, result := range i.knownImages {
+		if index.Raw().String() == imageName {
+			return result.imageResult.OCIConfig, nil
+		}
+	}
+
+	return nil, fmt.Errorf("image not found: %s", imageName)
 }

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+)
+
+// imageServiceVM is the ImageServer interface implementation that is more appropriate
+// for VM based container runtimes.
+type imageServiceVM struct {
+	ctx context.Context
+
+	// link to an ImageServer that is used to perform some of the image management
+	// operations. This allows imageServiceVM to delegate the core image handling tasks
+	// to the storage.ImageServer, while providing a VM-specific interface where
+	// needed.
+	storageImageServer ImageServer
+}
+
+// GetImageServiceVM creates a new imageServiceVM instance.
+func GetImageServiceVM(ctx context.Context, imageServer ImageServer) ImageServer {
+	return &imageServiceVM{
+		ctx:                ctx,
+		storageImageServer: imageServer,
+	}
+}
+
+// ListImages returns list of all images.
+func (i *imageServiceVM) ListImages(systemContext *types.SystemContext) ([]ImageResult, error) {
+	log.Debugf(i.ctx, "ImageServiceVM.ListImages() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.ListImages() end")
+	return i.storageImageServer.ListImages(systemContext)
+}
+
+// ImageStatusByID returns status of a single image
+func (i *imageServiceVM) ImageStatusByID(systemContext *types.SystemContext, id StorageImageID) (*ImageResult, error) {
+	log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByID() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByID() end")
+	return i.storageImageServer.ImageStatusByID(systemContext, id)
+}
+
+// ImageStatusByName returns status of an image tagged with name.
+func (i *imageServiceVM) ImageStatusByName(systemContext *types.SystemContext, name RegistryImageReference) (*ImageResult, error) {
+	log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByName() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByName() end")
+	return i.storageImageServer.ImageStatusByName(systemContext, name)
+}
+
+// PullImage imports an image from the specified location.
+//
+// Arguments:
+// - ctx: The context for controlling the function's execution
+// - imageName: A RegistryImageReference representing the image to be pulled
+// - options: Pointer to ImageCopyOptions, which contains various options for the image copy process
+//
+// Returns:
+//   - A name@digest value referring to exactly the pulled image (the reference might become dangling if the image
+//     is removed, but it will not ever match a different image). The value is suitable for PullImageResponse.ImageRef
+//     and for ContainerConfig.Image.Image.
+//   - error: An error object if pulling the image fails, otherwise nil
+func (i *imageServiceVM) PullImage(ctx context.Context, imageName RegistryImageReference, options *ImageCopyOptions) (RegistryImageReference, error) {
+	log.Debugf(i.ctx, "ImageServiceVM.PullImage() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.PullImage() end")
+	return i.storageImageServer.PullImage(ctx, imageName, options)
+}
+
+// DeleteImage deletes a storage image (impacting all its tags)
+func (i *imageServiceVM) DeleteImage(systemContext *types.SystemContext, id StorageImageID) error {
+	log.Debugf(i.ctx, "ImageServiceVM.DeleteImage() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.DeleteImage() end")
+	return i.storageImageServer.DeleteImage(systemContext, id)
+}
+
+// UntagImage removes a name from the specified image, and if it was
+// the only name the image had, removes the image.
+func (i *imageServiceVM) UntagImage(systemContext *types.SystemContext, name RegistryImageReference) error {
+	log.Debugf(i.ctx, "ImageServiceVM.UntagImage() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.UntagImage() end")
+	return i.storageImageServer.UntagImage(systemContext, name)
+}
+
+// GetStore returns the reference to the storage library Store which
+// the image server uses to hold images, and is the destination used
+// when it's asked to pull an image.
+func (i *imageServiceVM) GetStore() storage.Store {
+	log.Debugf(i.ctx, "ImageServiceVM.GetStore() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.GetStore() end")
+	return i.storageImageServer.GetStore()
+}
+
+// HeuristicallyTryResolvingStringAsIDPrefix checks if heuristicInput could be a valid image ID or a prefix, and returns
+// a StorageImageID if so, or nil if the input can be something else.
+// DO NOT CALL THIS from in-process callers who know what their input is and don't NEED to involve heuristics.
+func (i *imageServiceVM) HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput string) *StorageImageID {
+	log.Debugf(i.ctx, "ImageServiceVM.HeuristicallyTryResolvingStringAsIDPrefix() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.HeuristicallyTryResolvingStringAsIDPrefix() end")
+	return i.storageImageServer.HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput)
+}
+
+// CandidatesForPotentiallyShortImageName resolves an image name into a set of fully-qualified image names (domain/repo/image:tag|@digest).
+// It will only return an empty slice if err != nil.
+func (i *imageServiceVM) CandidatesForPotentiallyShortImageName(systemContext *types.SystemContext, imageName string) ([]RegistryImageReference, error) {
+	log.Debugf(i.ctx, "ImageServiceVM.CandidatesForPotentiallyShortImageName() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.CandidatesForPotentiallyShortImageName() end")
+	return i.storageImageServer.CandidatesForPotentiallyShortImageName(systemContext, imageName)
+}
+
+// UpdatePinnedImagesList updates pinned and pause images list in imageService.
+func (i *imageServiceVM) UpdatePinnedImagesList(imageList []string) {
+	log.Debugf(i.ctx, "ImageServiceVM.UpdatePinnedImagesList() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.UpdatePinnedImagesList() end")
+	i.storageImageServer.UpdatePinnedImagesList(imageList)
+}
+
+// IsRunningImageAllowed verifies if running of the container image is allowed.
+//
+// Arguments:
+// - ctx: The context for controlling the function's execution
+// - systemContext: server's system context for the given namespace, notably it might have a customized SignaturePolicyPath.
+// - userSpecifiedImage: a RegistryImageReference that expresses users’ _intended_ image.
+// - imageID: A StorageImageID of the image
+func (i *imageServiceVM) IsRunningImageAllowed(ctx context.Context, systemContext *types.SystemContext, userSpecifiedImage RegistryImageReference, imageID StorageImageID) error {
+	log.Debugf(i.ctx, "ImageServiceVM.IsRunningImageAllowed() start")
+	defer log.Debugf(i.ctx, "ImageServiceVM.IsRunningImageAllowed() end")
+	return i.storageImageServer.IsRunningImageAllowed(ctx, systemContext, userSpecifiedImage, imageID)
+}

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -2,11 +2,21 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/ociartifact"
+	"github.com/cri-o/cri-o/internal/storage/references"
+	"go.podman.io/common/libimage"
+	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 )
+
+type cachedImageRefs struct {
+	imageResult    ImageResult
+	storageImageID StorageImageID
+}
 
 // imageServiceVM is the ImageServer interface implementation that is more appropriate
 // for VM based container runtimes.
@@ -17,14 +27,22 @@ type imageServiceVM struct {
 	// operations. This allows imageServiceVM to delegate the core image handling tasks
 	// to the storage.ImageServer, while providing a VM-specific interface where
 	// needed.
-	storageImageServer ImageServer
+	storageImageServer *imageService
+
+	// FIXME: we're currently storing the StorageImageId and ImageResult in memory.
+	// We should find a way to persist this information in the storage, so that
+	// it can survive a restart of CRI-O.
+
+	// list of known RegistryImageReference with associated ImageResult and StorageID
+	knownImages map[RegistryImageReference]cachedImageRefs
 }
 
 // GetImageServiceVM creates a new imageServiceVM instance.
-func GetImageServiceVM(ctx context.Context, imageServer ImageServer) ImageServer {
+func GetImageServiceVM(ctx context.Context, imageService *imageService) ImageServer {
 	return &imageServiceVM{
 		ctx:                ctx,
-		storageImageServer: imageServer,
+		storageImageServer: imageService,
+		knownImages:        make(map[RegistryImageReference]cachedImageRefs),
 	}
 }
 
@@ -39,6 +57,13 @@ func (i *imageServiceVM) ListImages(systemContext *types.SystemContext) ([]Image
 func (i *imageServiceVM) ImageStatusByID(systemContext *types.SystemContext, id StorageImageID) (*ImageResult, error) {
 	log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByID() start")
 	defer log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByID() end")
+
+	for _, result := range i.knownImages {
+		if result.storageImageID == id {
+			return &result.imageResult, nil
+		}
+	}
+
 	return i.storageImageServer.ImageStatusByID(systemContext, id)
 }
 
@@ -46,25 +71,98 @@ func (i *imageServiceVM) ImageStatusByID(systemContext *types.SystemContext, id 
 func (i *imageServiceVM) ImageStatusByName(systemContext *types.SystemContext, name RegistryImageReference) (*ImageResult, error) {
 	log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByName() start")
 	defer log.Debugf(i.ctx, "ImageServiceVM.ImageStatusByName() end")
+
+	// look at our list of known image references, and if we find a match
+	// return the associated ImageResult.
+	if result, exists := i.knownImages[name]; exists {
+		return &result.imageResult, nil
+	}
+
 	return i.storageImageServer.ImageStatusByName(systemContext, name)
 }
 
-// PullImage imports an image from the specified location.
+// PullImage: do not pull the data, only get the manifest and return an image reference
 //
-// Arguments:
-// - ctx: The context for controlling the function's execution
-// - imageName: A RegistryImageReference representing the image to be pulled
-// - options: Pointer to ImageCopyOptions, which contains various options for the image copy process
-//
-// Returns:
-//   - A name@digest value referring to exactly the pulled image (the reference might become dangling if the image
-//     is removed, but it will not ever match a different image). The value is suitable for PullImageResponse.ImageRef
-//     and for ContainerConfig.Image.Image.
-//   - error: An error object if pulling the image fails, otherwise nil
+// For this runtime, the image management is done within the VM that will run
+// the container. CRI-O has nothing to do with the image, and must actually avoid
+// pulling it, as it may fail if the image is encrypted for instance.
 func (i *imageServiceVM) PullImage(ctx context.Context, imageName RegistryImageReference, options *ImageCopyOptions) (RegistryImageReference, error) {
 	log.Debugf(i.ctx, "ImageServiceVM.PullImage() start")
 	defer log.Debugf(i.ctx, "ImageServiceVM.PullImage() end")
-	return i.storageImageServer.PullImage(ctx, imageName, options)
+	log.Debugf(ctx, "Skip image pull for runtime %s - image %s", "", imageName)
+
+	srcRef, err := i.storageImageServer.lookup.remoteImageReference(imageName)
+	if err != nil {
+		return RegistryImageReference{}, err
+	}
+
+	srcSystemContext := types.SystemContext{}
+	if options.SourceCtx != nil {
+		srcSystemContext = *options.SourceCtx // A shallow copy
+	}
+
+	artifactStore, artifactErr := ociartifact.NewStore(i.GetStore().GraphRoot(), &srcSystemContext)
+	if artifactErr != nil {
+		return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: create store err: %w", artifactErr)
+	}
+
+	artifactManifestDigest, artifactErr := artifactStore.PullManifest(ctx, srcRef, &libimage.CopyOptions{
+		OciDecryptConfig: options.OciDecryptConfig,
+		Progress:         options.Progress,
+		RemoveSignatures: true, // signature is not supported for OCI layout dest
+	})
+	if artifactErr != nil {
+		return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: pull image err: %w; artifact err: %w", err, artifactErr)
+	}
+
+	canonicalRef, err := reference.WithDigest(reference.TrimNamed(imageName.Raw()), *artifactManifestDigest)
+	if err != nil {
+		return RegistryImageReference{}, fmt.Errorf("create canonical reference: %w", err)
+	}
+
+	imageRef := references.RegistryImageReferenceFromRaw(canonicalRef)
+
+	// create the StorageImageID from the manifest digest
+	ID := newExactStorageImageID(artifactManifestDigest.Encoded())
+
+	// Generate an ImageResult with the available information, so that it can be
+	// returned by ImageStatus when asked with the same reference.
+	// Note that this structure is incomplete, since we're not actually pulling
+	// the image.
+	var repoTags []string
+	var repoDigests []string
+
+	if tagged, ok := imageRef.Raw().(reference.NamedTagged); ok {
+		repoTags = append(repoTags, tagged.String())
+	}
+
+	repoDigests = append(repoDigests, artifactManifestDigest.String())
+
+	imageResult := &ImageResult{
+		ID:                  ID,
+		SomeNameOfThisImage: &imageRef,
+		RepoTags:            repoTags,
+		RepoDigests:         repoDigests,
+		Digest:              *artifactManifestDigest,
+		// Following fields are not available at this stage, and will be left
+		// emty, or with default value
+		Size:         nil,
+		User:         "",
+		PreviousName: "",
+		Labels:       nil,
+		OCIConfig:    nil,
+		Annotations:  nil,
+		Pinned:       false,
+		MountPoint:   "",
+	}
+
+	// Store the generated ImageResult and StorageImageID in our in-memory list of known images
+	i.knownImages[imageName] = cachedImageRefs{
+		imageResult:    *imageResult,
+		storageImageID: ID,
+	}
+
+	return imageRef, nil
 }
 
 // DeleteImage deletes a storage image (impacting all its tags)
@@ -97,6 +195,13 @@ func (i *imageServiceVM) GetStore() storage.Store {
 func (i *imageServiceVM) HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput string) *StorageImageID {
 	log.Debugf(i.ctx, "ImageServiceVM.HeuristicallyTryResolvingStringAsIDPrefix() start")
 	defer log.Debugf(i.ctx, "ImageServiceVM.HeuristicallyTryResolvingStringAsIDPrefix() end")
+
+	for index, result := range i.knownImages {
+		if index.Raw().String() == heuristicInput {
+			return &result.storageImageID
+		}
+	}
+
 	return i.storageImageServer.HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput)
 }
 
@@ -105,7 +210,35 @@ func (i *imageServiceVM) HeuristicallyTryResolvingStringAsIDPrefix(heuristicInpu
 func (i *imageServiceVM) CandidatesForPotentiallyShortImageName(systemContext *types.SystemContext, imageName string) ([]RegistryImageReference, error) {
 	log.Debugf(i.ctx, "ImageServiceVM.CandidatesForPotentiallyShortImageName() start")
 	defer log.Debugf(i.ctx, "ImageServiceVM.CandidatesForPotentiallyShortImageName() end")
-	return i.storageImageServer.CandidatesForPotentiallyShortImageName(systemContext, imageName)
+
+	// get candidates from the underlying storage image server
+	candidates, err := i.storageImageServer.CandidatesForPotentiallyShortImageName(systemContext, imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	// add the know image references from our in-memory list of ImageResults
+	for _, result := range i.knownImages {
+		if result.imageResult.SomeNameOfThisImage != nil {
+			candidateName := result.imageResult.SomeNameOfThisImage.Raw().String()
+			// Check if the candidate name matches the input image name
+			// skip duplicates
+			if candidateName == imageName {
+				alreadyPresent := false
+				for _, existing := range candidates {
+					if existing.Raw().String() == candidateName {
+						alreadyPresent = true
+						break
+					}
+				}
+				if !alreadyPresent {
+					candidates = append(candidates, *result.imageResult.SomeNameOfThisImage)
+				}
+			}
+		}
+	}
+
+	return candidates, nil
 }
 
 // UpdatePinnedImagesList updates pinned and pause images list in imageService.

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -1,0 +1,22 @@
+package storage
+
+import "context"
+
+// The runtimeServiceManager object is responsible for maintaining different
+// instances of runtimeService.
+// It allows for easy switching between different runtime services using different
+// image service managers in the backend.
+type RuntimeServiceManager struct {
+	runtimeService *runtimeService
+}
+
+func (r *RuntimeServiceManager) GetRuntimeService() RuntimeServer {
+	return r.runtimeService
+}
+
+func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageServiceManager, storageTransport StorageTransport) *RuntimeServiceManager {
+	rs := GetRuntimeService(ctx, imageServiceMgr.imageService, storageTransport)
+	return &RuntimeServiceManager{
+		runtimeService: rs.(*runtimeService),
+	}
+}

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -8,18 +8,18 @@ import "context"
 // image service managers in the backend.
 type RuntimeServiceManager struct {
 	runtimeService   *runtimeService
-	runtimeServiceVM *runtimeService
+	runtimeServiceVM *runtimeServiceVM
 }
 
 func (r *RuntimeServiceManager) GetRuntimeService() RuntimeServer {
-	return r.runtimeService
+	return r.runtimeServiceVM
 }
 
 func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageServiceManager, storageTransport StorageTransport) *RuntimeServiceManager {
 	rs := GetRuntimeService(ctx, imageServiceMgr.imageService, storageTransport)
-	rs_vm := GetRuntimeService(ctx, imageServiceMgr.imageServiceVM, storageTransport)
+	rs_vm := GetRuntimeServiceVM(ctx, rs, imageServiceMgr.imageServiceVM, storageTransport)
 	return &RuntimeServiceManager{
 		runtimeService:   rs.(*runtimeService),
-		runtimeServiceVM: rs_vm.(*runtimeService),
+		runtimeServiceVM: rs_vm.(*runtimeServiceVM),
 	}
 }

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -7,7 +7,8 @@ import "context"
 // It allows for easy switching between different runtime services using different
 // image service managers in the backend.
 type RuntimeServiceManager struct {
-	runtimeService *runtimeService
+	runtimeService   *runtimeService
+	runtimeServiceVM *runtimeService
 }
 
 func (r *RuntimeServiceManager) GetRuntimeService() RuntimeServer {
@@ -16,7 +17,9 @@ func (r *RuntimeServiceManager) GetRuntimeService() RuntimeServer {
 
 func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageServiceManager, storageTransport StorageTransport) *RuntimeServiceManager {
 	rs := GetRuntimeService(ctx, imageServiceMgr.imageService, storageTransport)
+	rs_vm := GetRuntimeService(ctx, imageServiceMgr.imageServiceVM, storageTransport)
 	return &RuntimeServiceManager{
-		runtimeService: rs.(*runtimeService),
+		runtimeService:   rs.(*runtimeService),
+		runtimeServiceVM: rs_vm.(*runtimeService),
 	}
 }

--- a/internal/storage/runtime_vm.go
+++ b/internal/storage/runtime_vm.go
@@ -1,0 +1,255 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/sirupsen/logrus"
+	istorage "go.podman.io/image/v5/storage"
+	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+)
+
+// runtimeServiceVM is a RuntimeServer implementation dedicated to VM-based
+// runtimes. It is designed to do most operation using the regular container
+// management workflow, but will delegate to a different ImageService when
+// image management must be done by the runtimme.
+type runtimeServiceVM struct {
+	// Pointer to the runtimeService used for regular containers operations
+	// Must be provided by the caller, and will be used to delegate operations
+	// that don't need a specific behaviour for the VM runtime.
+	runtimeServiceOCI RuntimeServer
+
+	// Pointer to a runtimeService instance that uses an imageVM image service
+	// in place of the regular one. This is used for operations that requires
+	// sepcific handling of the image management.
+	runtimeServiceVM RuntimeServer
+
+	storageImageServer ImageServer
+	ctx                context.Context
+}
+
+func (r *runtimeServiceVM) createContainerOrPodSandbox(systemContext *types.SystemContext, containerID string, template *runtimeContainerMetadataTemplate, idMappingsOptions *storage.IDMappingOptions, labelOptions []string) (ci ContainerInfo, retErr error) {
+	if template.podName == "" || template.podID == "" {
+		return ContainerInfo{}, ErrInvalidPodName
+	}
+
+	if template.containerName == "" {
+		return ContainerInfo{}, ErrInvalidContainerName
+	}
+
+	// Build metadata to store with the container.
+	metadata := RuntimeContainerMetadata{
+		PodName:       template.podName,
+		PodID:         template.podID,
+		ImageName:     template.userRequestedImage,
+		ImageID:       template.imageID.IDStringForOutOfProcessConsumptionOnly(),
+		ContainerName: template.containerName,
+		MetadataName:  template.metadataName,
+		UID:           template.uid,
+		Namespace:     template.namespace,
+		MountLabel:    "",
+		// CreatedAt is set later
+		Attempt: template.attempt,
+		// Pod is set later
+		Privileged: template.privileged,
+	}
+	if metadata.MetadataName == "" {
+		metadata.MetadataName = metadata.ContainerName
+	}
+
+	// Pull out a copy of the image's configuration.
+	// Ideally we would call imageID.imageRef(r.storageImageServer), but storageImageServer does not have access to private data.
+	ref, err := istorage.Transport.NewStoreReference(r.storageImageServer.GetStore(), nil, template.imageID.privateID)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	image, err := ref.NewImage(r.ctx, systemContext)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	defer image.Close()
+
+	imageConfig, err := image.OCIConfig(r.ctx)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	metadata.Pod = (containerID == metadata.PodID) // Or should this be hard-coded in callers? The caller should know whether it is creating the infra container.
+	metadata.CreatedAt = time.Now().Unix()
+
+	mdata, err := json.Marshal(&metadata)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	// Build the container.
+	names := []string{metadata.ContainerName}
+	if metadata.Pod {
+		names = append(names, metadata.PodName)
+	}
+
+	coptions := storage.ContainerOptions{
+		LabelOpts: labelOptions,
+		Volatile:  true,
+	}
+	if idMappingsOptions != nil {
+		coptions.IDMappingOptions = *idMappingsOptions
+	}
+
+	container, err := r.storageImageServer.GetStore().CreateContainer(containerID, names, template.imageID.privateID, "", string(mdata), &coptions)
+	if err != nil {
+		if metadata.Pod {
+			logrus.Debugf("Failed to create pod sandbox %s(%s): %v", metadata.PodName, metadata.PodID, err)
+		} else {
+			logrus.Debugf("Failed to create container %s(%s): %v", metadata.ContainerName, containerID, err)
+		}
+
+		return ContainerInfo{}, err
+	}
+
+	if idMappingsOptions != nil {
+		idMappingsOptions.UIDMap = container.UIDMap
+		idMappingsOptions.GIDMap = container.GIDMap
+	}
+
+	if metadata.Pod {
+		logrus.Debugf("Created pod sandbox %q", container.ID)
+	} else {
+		logrus.Debugf("Created container %q", container.ID)
+	}
+
+	// If anything fails after this point, we need to delete the incomplete
+	// container before returning.
+	defer func() {
+		if retErr != nil {
+			if err2 := r.storageImageServer.GetStore().DeleteContainer(container.ID); err2 != nil {
+				if metadata.Pod {
+					logrus.Debugf("%v deleting partially-created pod sandbox %q", err2, container.ID)
+				} else {
+					logrus.Debugf("%v deleting partially-created container %q", err2, container.ID)
+				}
+
+				return
+			}
+
+			logrus.Debugf("Deleted partially-created container %q", container.ID)
+		}
+	}()
+
+	// Add a name to the container's layer so that it's easier to follow
+	// what's going on if we're just looking at the storage-eye view of things.
+	layerName := metadata.ContainerName + "-layer"
+
+	err = r.storageImageServer.GetStore().AddNames(container.LayerID, []string{layerName})
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	// Find out where the container work directories are, so that we can return them.
+	containerDir, err := r.storageImageServer.GetStore().ContainerDirectory(container.ID)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	if metadata.Pod {
+		logrus.Debugf("Pod sandbox %q has work directory %q", container.ID, containerDir)
+	} else {
+		logrus.Debugf("Container %q has work directory %q", container.ID, containerDir)
+	}
+
+	containerRunDir, err := r.storageImageServer.GetStore().ContainerRunDirectory(container.ID)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	if metadata.Pod {
+		logrus.Debugf("Pod sandbox %q has run directory %q", container.ID, containerRunDir)
+	} else {
+		logrus.Debugf("Container %q has run directory %q", container.ID, containerRunDir)
+	}
+
+	metadata.MountLabel = container.MountLabel()
+
+	return ContainerInfo{
+		ID:           container.ID,
+		Dir:          containerDir,
+		RunDir:       containerRunDir,
+		Config:       imageConfig,
+		ProcessLabel: container.ProcessLabel(),
+		MountLabel:   container.MountLabel(),
+	}, nil
+}
+
+func (r *runtimeServiceVM) CreatePodSandbox(systemContext *types.SystemContext, podName, podID string, pauseImage RegistryImageReference, imageAuthFile, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
+	// For the VM runtime, we create the pod sandbox using the same underlying
+	// service as for regualr containers, because at this point the VM doesn't
+	// exist and cannot assume the container image pull.
+	return r.runtimeServiceOCI.CreatePodSandbox(systemContext, podName, podID, pauseImage, imageAuthFile, containerName, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, privileged)
+}
+
+func (r *runtimeServiceVM) CreateContainer(systemContext *types.SystemContext, podName, podID, userRequestedImage string, imageID StorageImageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, containerID, &runtimeContainerMetadataTemplate{
+		podName:            podName,
+		podID:              podID,
+		userRequestedImage: userRequestedImage,
+		imageID:            imageID,
+		containerName:      containerName,
+		metadataName:       metadataName,
+		uid:                "",
+		namespace:          "",
+		attempt:            attempt,
+		privileged:         privileged,
+	}, idMappingsOptions, labelOptions)
+}
+
+func (r *runtimeServiceVM) DeleteContainer(ctx context.Context, idOrName string) error {
+	return r.runtimeServiceOCI.DeleteContainer(ctx, idOrName)
+}
+
+func (r *runtimeServiceVM) SetContainerMetadata(idOrName string, metadata *RuntimeContainerMetadata) error {
+	return r.runtimeServiceOCI.SetContainerMetadata(idOrName, metadata)
+}
+
+func (r *runtimeServiceVM) GetContainerMetadata(idOrName string) (RuntimeContainerMetadata, error) {
+	return r.runtimeServiceOCI.GetContainerMetadata(idOrName)
+}
+
+func (r *runtimeServiceVM) StartContainer(idOrName string) (string, error) {
+	return r.runtimeServiceOCI.StartContainer(idOrName)
+}
+
+func (r *runtimeServiceVM) StopContainer(ctx context.Context, idOrName string) error {
+	return r.runtimeServiceOCI.StopContainer(ctx, idOrName)
+}
+
+func (r *runtimeServiceVM) GetWorkDir(id string) (string, error) {
+	return r.runtimeServiceOCI.GetWorkDir(id)
+}
+
+func (r *runtimeServiceVM) GetRunDir(id string) (string, error) {
+	return r.runtimeServiceOCI.GetRunDir(id)
+}
+
+// GetRuntimeServiceVM returns a RuntimeServer that uses the passed-in image
+// service to pull and manage images, and its store to manage containers based
+// on those images.
+// The provided ImageServer must be an instance of ImageServiceVM
+func GetRuntimeServiceVM(ctx context.Context, runtimeService RuntimeServer, storageImageServer ImageServer, storageTransport StorageTransport) RuntimeServer {
+	if storageTransport == nil {
+		storageTransport = nativeStorageTransport{}
+	}
+
+	// create an instance of runtimeService that is backed by the provided ImageServer
+	rs_vm := GetRuntimeService(ctx, storageImageServer, storageTransport)
+
+	return &runtimeServiceVM{
+		runtimeServiceOCI:  runtimeService,
+		runtimeServiceVM:   rs_vm,
+		storageImageServer: storageImageServer,
+		ctx:                ctx,
+	}
+}

--- a/internal/storage/runtime_vm.go
+++ b/internal/storage/runtime_vm.go
@@ -6,7 +6,6 @@ import (
 
 	json "github.com/goccy/go-json"
 	"github.com/sirupsen/logrus"
-	istorage "go.podman.io/image/v5/storage"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 )
@@ -26,7 +25,7 @@ type runtimeServiceVM struct {
 	// sepcific handling of the image management.
 	runtimeServiceVM RuntimeServer
 
-	storageImageServer ImageServer
+	storageImageServer *imageServiceVM
 	ctx                context.Context
 }
 
@@ -60,20 +59,7 @@ func (r *runtimeServiceVM) createContainerOrPodSandbox(systemContext *types.Syst
 	}
 
 	// Pull out a copy of the image's configuration.
-	// Ideally we would call imageID.imageRef(r.storageImageServer), but storageImageServer does not have access to private data.
-	ref, err := istorage.Transport.NewStoreReference(r.storageImageServer.GetStore(), nil, template.imageID.privateID)
-	if err != nil {
-		return ContainerInfo{}, err
-	}
-
-	image, err := ref.NewImage(r.ctx, systemContext)
-	if err != nil {
-		return ContainerInfo{}, err
-	}
-
-	defer image.Close()
-
-	imageConfig, err := image.OCIConfig(r.ctx)
+	imageConfig, err := r.storageImageServer.GetConfigForImage(r.ctx, template.userRequestedImage)
 	if err != nil {
 		return ContainerInfo{}, err
 	}
@@ -100,7 +86,10 @@ func (r *runtimeServiceVM) createContainerOrPodSandbox(systemContext *types.Syst
 		coptions.IDMappingOptions = *idMappingsOptions
 	}
 
-	container, err := r.storageImageServer.GetStore().CreateContainer(containerID, names, template.imageID.privateID, "", string(mdata), &coptions)
+	// Call CreateContainer with an empty image name, to avoid image lookup
+	// as we don't actually want to create this container with a local image.
+	imageID := ""
+	container, err := r.storageImageServer.GetStore().CreateContainer(containerID, names, imageID, "", string(mdata), &coptions)
 	if err != nil {
 		if metadata.Pod {
 			logrus.Debugf("Failed to create pod sandbox %s(%s): %v", metadata.PodName, metadata.PodID, err)
@@ -238,7 +227,7 @@ func (r *runtimeServiceVM) GetRunDir(id string) (string, error) {
 // service to pull and manage images, and its store to manage containers based
 // on those images.
 // The provided ImageServer must be an instance of ImageServiceVM
-func GetRuntimeServiceVM(ctx context.Context, runtimeService RuntimeServer, storageImageServer ImageServer, storageTransport StorageTransport) RuntimeServer {
+func GetRuntimeServiceVM(ctx context.Context, runtimeService RuntimeServer, storageImageServer *imageServiceVM, storageTransport StorageTransport) RuntimeServer {
 	if storageTransport == nil {
 		storageTransport = nativeStorageTransport{}
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1319,7 +1319,7 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 		someRepoDigest = imgResult.RepoDigests[0]
 	}
 
-	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult); err != nil {
+	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult, sb.RuntimeHandler()); err != nil {
 		return nil, err
 	}
 
@@ -1421,7 +1421,7 @@ func configureTimezone(tz, containerRunDir, mountPoint, mountLabel, etcPath, con
 }
 
 // verifyImageSignature verifies the signature of a container image.
-func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult) error {
+func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult, runtimeHandler string) error {
 	systemCtx, err := s.contextForNamespace(namespace)
 	if err != nil {
 		return fmt.Errorf("get context for namespace: %w", err)
@@ -1445,7 +1445,7 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 			return fmt.Errorf("unable to get userSpecifiedImageRef from user specified image %q: %w", userSpecifiedImage, err)
 		}
 
-		if err := s.ContainerServer.ImageServiceMgr().GetImageService("").IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+		if err := s.ContainerServer.ImageServiceMgr().GetImageService(runtimeHandler).IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
 			return err
 		}
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1282,20 +1282,21 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 	}
 
 	var imgResult *storage.ImageResult
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
-		imgResult, err = s.ContainerServer.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService()
+	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
+		imgResult, err = imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
+		potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
 		if err != nil {
 			return nil, err
 		}
 
 		var imgResultErr error
 		for _, name := range potentialMatches {
-			imgResult, imgResultErr = s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+			imgResult, imgResultErr = imageService.ImageStatusByName(s.config.SystemContext, name)
 			if imgResultErr == nil {
 				break
 			}
@@ -1444,7 +1445,7 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 			return fmt.Errorf("unable to get userSpecifiedImageRef from user specified image %q: %w", userSpecifiedImage, err)
 		}
 
-		if err := s.ContainerServer.StorageImageServer().IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+		if err := s.ContainerServer.ImageServiceMgr().GetImageService().IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
 			return err
 		}
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1282,7 +1282,7 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 	}
 
 	var imgResult *storage.ImageResult
-	imageService := s.ContainerServer.ImageServiceMgr().GetImageService()
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService(sb.RuntimeHandler())
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
 		imgResult, err = imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1445,7 +1445,7 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 			return fmt.Errorf("unable to get userSpecifiedImageRef from user specified image %q: %w", userSpecifiedImage, err)
 		}
 
-		if err := s.ContainerServer.ImageServiceMgr().GetImageService().IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+		if err := s.ContainerServer.ImageServiceMgr().GetImageService("").IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
 			return err
 		}
 	}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -528,7 +528,7 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 	imageID := status.ID.IDStringForOutOfProcessConsumptionOnly()
 
 	// Check the signature of the image
-	if err := s.verifyImageSignature(ctx, namespace, m.GetImage().GetUserSpecifiedImage(), status); err != nil {
+	if err := s.verifyImageSignature(ctx, namespace, m.GetImage().GetUserSpecifiedImage(), status, m.GetImage().GetRuntimeHandler()); err != nil {
 		return nil, nil, err
 	}
 

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -94,7 +94,7 @@ func (s *Server) CRImportCheckpoint(
 		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-		mountPoint, err = s.ContainerServer.StorageImageServer().GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
+		mountPoint, err = s.ContainerServer.ImageServiceMgr().GetImageService().GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
 		if err != nil {
 			return "", err
 		}
@@ -103,7 +103,7 @@ func (s *Server) CRImportCheckpoint(
 
 		defer func() {
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			if _, err := s.ContainerServer.StorageImageServer().GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
+			if _, err := s.ContainerServer.ImageServiceMgr().GetImageService().GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
 				log.Errorf(ctx, "Could not unmount checkpoint image %s: %q", restoreStorageImageID, err)
 			}
 		}()

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -94,7 +94,7 @@ func (s *Server) CRImportCheckpoint(
 		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-		mountPoint, err = s.ContainerServer.ImageServiceMgr().GetImageService().GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
+		mountPoint, err = s.ContainerServer.ImageServiceMgr().GetImageService("").GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
 		if err != nil {
 			return "", err
 		}
@@ -103,7 +103,7 @@ func (s *Server) CRImportCheckpoint(
 
 		defer func() {
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			if _, err := s.ContainerServer.ImageServiceMgr().GetImageService().GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
+			if _, err := s.ContainerServer.ImageServiceMgr().GetImageService("").GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
 				log.Errorf(ctx, "Could not unmount checkpoint image %s: %q", restoreStorageImageID, err)
 			}
 		}()

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -94,7 +94,7 @@ func (s *Server) CRImportCheckpoint(
 		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-		mountPoint, err = s.ContainerServer.ImageServiceMgr().GetImageService("").GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
+		mountPoint, err = s.ContainerServer.ImageServiceMgr().GetImageService(sb.RuntimeHandler()).GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
 		if err != nil {
 			return "", err
 		}
@@ -103,7 +103,7 @@ func (s *Server) CRImportCheckpoint(
 
 		defer func() {
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			if _, err := s.ContainerServer.ImageServiceMgr().GetImageService("").GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
+			if _, err := s.ContainerServer.ImageServiceMgr().GetImageService(sb.RuntimeHandler()).GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
 				log.Errorf(ctx, "Could not unmount checkpoint image %s: %q", restoreStorageImageID, err)
 			}
 		}()

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -55,7 +55,7 @@ func getStorageFsInfo(store storage.Store) (*types.ImageFsInfoResponse, error) {
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (s *Server) ImageFsInfo(context.Context, *types.ImageFsInfoRequest) (*types.ImageFsInfoResponse, error) {
-	store := s.ContainerServer.StorageImageServer().GetStore()
+	store := s.ContainerServer.ImageServiceMgr().GetImageService().GetStore()
 
 	fsUsage, err := getStorageFsInfo(store)
 	if err != nil {

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -55,7 +55,7 @@ func getStorageFsInfo(store storage.Store) (*types.ImageFsInfoResponse, error) {
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (s *Server) ImageFsInfo(context.Context, *types.ImageFsInfoRequest) (*types.ImageFsInfoResponse, error) {
-	store := s.ContainerServer.ImageServiceMgr().GetImageService().GetStore()
+	store := s.ContainerServer.ImageServiceMgr().GetImageService("").GetStore()
 
 	fsUsage, err := getStorageFsInfo(store)
 	if err != nil {

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -43,7 +43,11 @@ func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (
 		}
 	}
 
-	results, err := s.ContainerServer.ImageServiceMgr().GetImageService("").ListImages(s.config.SystemContext)
+	var runtimeHandler string
+	if filter := req.GetFilter(); filter != nil && filter.Image != nil {
+		runtimeHandler = filter.Image.GetRuntimeHandler()
+	}
+	results, err := s.ContainerServer.ImageServiceMgr().GetImageService(runtimeHandler).ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -43,7 +43,7 @@ func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (
 		}
 	}
 
-	results, err := s.ContainerServer.ImageServiceMgr().GetImageService().ListImages(s.config.SystemContext)
+	results, err := s.ContainerServer.ImageServiceMgr().GetImageService("").ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -43,7 +43,7 @@ func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (
 		}
 	}
 
-	results, err := s.ContainerServer.StorageImageServer().ListImages(s.config.SystemContext)
+	results, err := s.ContainerServer.ImageServiceMgr().GetImageService().ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -181,7 +181,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 		}
 	}
 
-	remoteCandidates, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
+	remoteCandidates, err := s.ContainerServer.ImageServiceMgr().GetImageService().CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return storage.RegistryImageReference{}, err
 	}
@@ -309,7 +309,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
 
-	repoDigest, err := s.ContainerServer.StorageImageServer().PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
+	repoDigest, err := s.ContainerServer.ImageServiceMgr().GetImageService().PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -181,7 +181,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 		}
 	}
 
-	remoteCandidates, err := s.ContainerServer.ImageServiceMgr().GetImageService().CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
+	remoteCandidates, err := s.ContainerServer.ImageServiceMgr().GetImageService("").CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return storage.RegistryImageReference{}, err
 	}
@@ -309,7 +309,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
 
-	repoDigest, err := s.ContainerServer.ImageServiceMgr().GetImageService().PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
+	repoDigest, err := s.ContainerServer.ImageServiceMgr().GetImageService("").PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -35,10 +35,12 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 	var err error
 
 	image := ""
+	runtimeHandler := ""
 	img := req.GetImage()
 
 	if img != nil {
 		image = img.GetImage()
+		runtimeHandler = img.GetRuntimeHandler()
 	}
 
 	log.Infof(ctx, "Pulling image: %s", image)
@@ -109,7 +111,7 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 			s.pullOperationsLock.Unlock()
 		}()
 
-		pullOp.imageRef, pullOp.err = s.pullImage(ctx, &pullArgs)
+		pullOp.imageRef, pullOp.err = s.pullImage(ctx, &pullArgs, runtimeHandler)
 	} else {
 		// Wait for the pull operation to finish.
 		pullOp.wg.Wait()
@@ -133,7 +135,7 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 // pullImage performs the actual pull operation of PullImage. Used to separate
 // the pull implementation from the pullCache logic in PullImage and improve
 // readability and maintainability.
-func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storage.RegistryImageReference, error) {
+func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments, runtimeHandler string) (storage.RegistryImageReference, error) {
 	var err error
 
 	ctx, span := log.StartSpan(ctx)
@@ -181,7 +183,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 		}
 	}
 
-	remoteCandidates, err := s.ContainerServer.ImageServiceMgr().GetImageService("").CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
+	remoteCandidates, err := s.ContainerServer.ImageServiceMgr().GetImageService(runtimeHandler).CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return storage.RegistryImageReference{}, err
 	}
@@ -190,7 +192,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 	lastErr := errors.New("internal error: pullImage failed but reported no error reason")
 
 	for _, remoteCandidateName := range remoteCandidates {
-		repoDigest, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup)
+		repoDigest, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup, runtimeHandler)
 		if err == nil {
 			// Update metric for successful image pulls
 			metrics.Instance().MetricImagePullsSuccessesInc(remoteCandidateName)
@@ -296,7 +298,7 @@ func (s *Server) prepareTempAuthFile(ctx context.Context, sysCtx *imageTypes.Sys
 	return cleanup, nil
 }
 
-func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup string) (storage.RegistryImageReference, error) {
+func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup string, runtimeHandler string) (storage.RegistryImageReference, error) {
 	// Collect pull progress metrics
 	progress := make(chan imageTypes.ProgressProperties)
 	defer close(progress)
@@ -309,7 +311,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
 
-	repoDigest, err := s.ContainerServer.ImageServiceMgr().GetImageService("").PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
+	repoDigest, err := s.ContainerServer.ImageServiceMgr().GetImageService(runtimeHandler).PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -40,7 +40,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	imageService := s.ContainerServer.ImageServiceMgr().GetImageService()
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService("")
 
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
 		if err := s.volumeInUse(id.IDStringForOutOfProcessConsumptionOnly()); err != nil {

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -29,18 +29,18 @@ func (s *Server) RemoveImage(ctx context.Context, req *types.RemoveImageRequest)
 		return nil, errors.New("no image specified")
 	}
 
-	if err := s.removeImage(ctx, imageRef); err != nil {
+	if err := s.removeImage(ctx, imageRef, img.GetRuntimeHandler()); err != nil {
 		return nil, err
 	}
 
 	return &types.RemoveImageResponse{}, nil
 }
 
-func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr error) {
+func (s *Server) removeImage(ctx context.Context, imageRef string, runtimeHandler string) (untagErr error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	imageService := s.ContainerServer.ImageServiceMgr().GetImageService("")
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService(runtimeHandler)
 
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
 		if err := s.volumeInUse(id.IDStringForOutOfProcessConsumptionOnly()); err != nil {

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -40,12 +40,14 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService()
+
+	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
 		if err := s.volumeInUse(id.IDStringForOutOfProcessConsumptionOnly()); err != nil {
 			return err
 		}
 
-		if err := s.ContainerServer.StorageImageServer().DeleteImage(s.config.SystemContext, *id); err != nil {
+		if err := imageService.DeleteImage(s.config.SystemContext, *id); err != nil {
 			if errors.Is(err, storagetypes.ErrImageUnknown) {
 				// The RemoveImage RPC is idempotent, and must not return an
 				// error if the image has already been removed. Ref:
@@ -64,7 +66,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 		statusErr error
 	)
 
-	potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
+	potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
 	if err != nil {
 		return err
 	}
@@ -72,7 +74,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	for _, name := range potentialMatches {
 		var status *storage.ImageResult
 
-		status, statusErr = s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+		status, statusErr = imageService.ImageStatusByName(s.config.SystemContext, name)
 		if statusErr != nil {
 			log.Warnf(ctx, "Error getting image status %s: %v", name, statusErr)
 
@@ -83,7 +85,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 			return err
 		}
 
-		untagErr = s.ContainerServer.StorageImageServer().UntagImage(s.config.SystemContext, name)
+		untagErr = imageService.UntagImage(s.config.SystemContext, name)
 		if untagErr != nil {
 			log.Debugf(ctx, "Error deleting image %s: %v", name, untagErr)
 

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -95,7 +95,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 // storageImageStatus calls ImageStatus for a k8s ImageSpec.
 // Returns (nil, nil) if image was not found.
 func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) (*pkgstorage.ImageResult, error) {
-	imageService := s.ContainerServer.ImageServiceMgr().GetImageService("")
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService(spec.GetRuntimeHandler())
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
 		status, err := imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -95,8 +95,9 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 // storageImageStatus calls ImageStatus for a k8s ImageSpec.
 // Returns (nil, nil) if image was not found.
 func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) (*pkgstorage.ImageResult, error) {
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
-		status, err := s.ContainerServer.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService()
+	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
+		status, err := imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
 			if errors.Is(err, istorage.ErrNoSuchImage) || errors.Is(err, storage.ErrImageUnknown) {
 				log.Infof(ctx, "Image %s not found", spec.GetImage())
@@ -112,7 +113,7 @@ func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) 
 		return status, nil
 	}
 
-	potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, spec.GetImage())
+	potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, spec.GetImage())
 	if err != nil {
 		if len(spec.GetImage()) >= 3 && isHexString(spec.GetImage()) {
 			log.Debugf(ctx, "CandidatesForPotentiallyShortImageName failed for %q, but input looks like digest/ID: %v", spec.GetImage(), err)
@@ -126,7 +127,7 @@ func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) 
 	var lastErr error
 
 	for _, name := range potentialMatches {
-		status, err := s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+		status, err := imageService.ImageStatusByName(s.config.SystemContext, name)
 		if err != nil {
 			if errors.Is(err, istorage.ErrNoSuchImage) {
 				log.Debugf(ctx, "Can't find %s", name)

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -95,7 +95,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 // storageImageStatus calls ImageStatus for a k8s ImageSpec.
 // Returns (nil, nil) if image was not found.
 func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) (*pkgstorage.ImageResult, error) {
-	imageService := s.ContainerServer.ImageServiceMgr().GetImageService()
+	imageService := s.ContainerServer.ImageServiceMgr().GetImageService("")
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
 		status, err := imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -632,7 +632,7 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			}
 			// ImageServer compiles the list with regex for both
 			// pinned and sandbox/pause images, we need to update them
-			s.ContainerServer.ImageServiceMgr().GetImageService().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
+			s.ContainerServer.ImageServiceMgr().GetImageService("").UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()
@@ -723,7 +723,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []storage
 	// disk usage gets too high.
 	if shouldWipeImages {
 		for img := range imageMapToDelete {
-			if err := s.ContainerServer.ImageServiceMgr().GetImageService().DeleteImage(s.config.SystemContext, img); err != nil {
+			if err := s.ContainerServer.ImageServiceMgr().GetImageService("").DeleteImage(s.config.SystemContext, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -632,7 +632,7 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			}
 			// ImageServer compiles the list with regex for both
 			// pinned and sandbox/pause images, we need to update them
-			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
+			s.ContainerServer.ImageServiceMgr().GetImageService().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()
@@ -723,7 +723,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []storage
 	// disk usage gets too high.
 	if shouldWipeImages {
 		for img := range imageMapToDelete {
-			if err := s.ContainerServer.StorageImageServer().DeleteImage(s.config.SystemContext, img); err != nil {
+			if err := s.ContainerServer.ImageServiceMgr().GetImageService().DeleteImage(s.config.SystemContext, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}
 		}


### PR DESCRIPTION
- Pass runtime handler to GetImageService() across image pull, list, status, remove, container create, and restore                      
- Fix nil dereference in image_list.go and image_pull.go when filter/image is nil 