### PR TITLE
test: add kata-remote integration test for runtime_pull_image

### DIFF
--- a/contrib/test/ci/build/kata.yml
+++ b/contrib/test/ci/build/kata.yml
@@ -72,3 +72,112 @@
         path: "/opt/kata/share/defaults/kata-containers/configuration.toml"
         regexp: "^#enable_debug = true"
         replace: "enable_debug = true"
+
+- name: Set up kata-remote (peer pods) environment
+  block:
+    - name: Install libvirt and QEMU
+      become: yes
+      package:
+        name:
+          - podman
+          - qemu-kvm
+          - libvirt
+          - libvirt-client
+          - virt-install
+        state: present
+
+    - name: Start and enable libvirtd
+      become: yes
+      systemd:
+        name: libvirtd
+        state: started
+        enabled: yes
+
+    - name: Configure libvirt storage pool
+      become: yes
+      shell: |
+        virsh pool-define-as default dir --target /var/lib/libvirt/images
+        virsh pool-autostart default
+        virsh pool-start default
+      args:
+        executable: /bin/bash
+
+    - name: Configure libvirt default network
+      become: yes
+      shell: |
+        virsh net-start default || true
+        virsh net-autostart default
+      args:
+        executable: /bin/bash
+
+    - name: Create required directories
+      become: yes
+      file:
+        path: "{{ item }}"
+        state: directory
+      loop:
+        - /run/peerpod
+        - /run/netns
+        - /opt/data-dir
+
+    - name: Create xtables lock file
+      become: yes
+      file:
+        path: /run/xtables.lock
+        state: touch
+
+    - name: Generate SSH key for libvirt access
+      become: yes
+      shell: |
+        ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa
+        cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+        chmod 600 /root/.ssh/authorized_keys
+        ssh-keyscan -H 192.168.122.1 >> /root/.ssh/known_hosts 2>/dev/null || true
+        ssh-keyscan -H localhost >> /root/.ssh/known_hosts 2>/dev/null || true
+      args:
+        executable: /bin/bash
+        creates: /root/.ssh/id_rsa
+
+    - name: Pull and extract podvm image
+      become: yes
+      shell: |
+        podman pull {{ podvm_image }}
+        podman create --name qcow_extractor {{ podvm_image }} /bin/true
+        QCOW=$(podman export qcow_extractor | tar t | grep '\.qcow2$')
+        podman cp "qcow_extractor:/$QCOW" /tmp/podvm.qcow2
+        podman rm qcow_extractor
+        virsh vol-create-as --pool default --name podvm-base.qcow2 \
+          --capacity 20G --allocation 2G --prealloc-metadata --format qcow2
+        virsh vol-upload --vol podvm-base.qcow2 /tmp/podvm.qcow2 --pool default --sparse
+        rm -f /tmp/podvm.qcow2
+      args:
+        executable: /bin/bash
+
+    - name: Start Cloud API Adaptor container
+      become: yes
+      shell: |
+        podman pull {{ caa_image }}
+        podman run -d \
+          --name caa \
+          --network host \
+          --cap-add NET_ADMIN \
+          --cap-add SYS_ADMIN \
+          --device /dev/kvm \
+          -e CLOUD_PROVIDER=libvirt \
+          -e LIBVIRT_URI="qemu+ssh://root@192.168.122.1/system?no_verify=1" \
+          -e LIBVIRT_POOL=default \
+          -e LIBVIRT_NET=default \
+          -e LIBVIRT_VOL_NAME=podvm-base.qcow2 \
+          -e DISABLECVM=true \
+          -v /root/.ssh/id_rsa:/root/.ssh/id_rsa:ro \
+          -v /run/peerpod:/run/peerpod \
+          -v /run/netns:/run/netns:rslave \
+          -v /run/xtables.lock:/run/xtables.lock \
+          -v /lib/modules:/lib/modules:ro \
+          -v /opt/data-dir:/opt/data-dir \
+          {{ caa_image }}
+        sleep 5
+        podman ps -a --filter name=caa
+        podman logs caa 2>&1 | tail -30
+      args:
+        executable: /bin/bash

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -43,6 +43,8 @@ ssh_location: "{{ lookup('env','HOME') }}/.ssh/id_rsa"
 
 # variables for testing with the kata-containers runtime
 kata_version: "3.6.0"
+podvm_image: "quay.io/confidential-containers/podvm-generic-ubuntu-amd64:v0.18.0"
+caa_image: "quay.io/confidential-containers/cloud-api-adaptor:v0.19.0-dev"
 
 kata_skip_files:
   - "apparmor.bats"

--- a/test/kata-remote.bats
+++ b/test/kata-remote.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "Container creation with runtime_pull_image=true" {
+	# Skip in non-kata environments where kata binaries aren't installed.
+	# In CI, RUNTIME_TYPE=vm is only set in kata matrix jobs.
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+
+	# Verify the cloud API adaptor (peerpod backend) is running
+	output=$(sudo podman inspect --format '{{.State.Status}}' caa 2>/dev/null || true)
+	[[ "$output" == "running" ]]
+
+	# setup_crio uses RUNTIME_TYPE to configure the default crun runtime.
+	# With RUNTIME_TYPE=vm, crun gets runtime_type="vm" and CRI-O rejects it
+	# because /usr/bin/crun doesn't match the containerd-shim-*-v2 naming pattern.
+	# kata-remote gets its own runtime_type="vm" from the drop-in config below.
+	RUNTIME_TYPE="oci"
+	setup_crio
+
+	cat > "$CRIO_CONFIG_DIR/50-kata.conf" <<-EOF
+	[crio.runtime.runtimes.kata-remote]
+	  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+	  runtime_root = "/run/vc"
+	  runtime_type = "vm"
+	  privileged_without_host_devices = true
+	  runtime_config_path = "/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
+	  runtime_pull_image = true
+	EOF
+
+	start_crio_no_setup
+	check_images
+
+	# Verify kata-remote runtime is registered
+	wait_for_log "kata-remote"
+
+	# Remove the container image from local storage so we can verify
+	# that runtime_pull_image=true pulls it inside the peer pod VM,
+	# not into the host's local storage.
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	crictl rmi "$test_image"
+	output=$(crictl images)
+	[[ "$output" != *"$test_image"* ]]
+
+	# Create pod
+	local runtimeclass=kata-remote
+	pod_id=$(crictl runp --runtime="$runtimeclass" "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_id" ]]
+
+	# Verify pod is ready
+	output=$(crictl inspectp "$pod_id" | jq -r '.status.state')
+	[[ "$output" == "SANDBOX_READY" ]]
+
+	# Create container with image pull
+	ctr_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr_id" ]]
+
+	# Verify image is still NOT in local storage — it was pulled inside the VM
+	output=$(crictl images)
+	[[ "$output" != *"$test_image"* ]]
+
+	# Verify container is created
+	output=$(crictl inspect "$ctr_id" | jq -r '.status.state')
+	[[ "$output" == "CONTAINER_CREATED" ]]
+
+	# Start container
+	crictl start "$ctr_id"
+
+	# Verify container is running
+	output=$(crictl inspect "$ctr_id" | jq -r '.status.state')
+	[[ "$output" == "CONTAINER_RUNNING" ]]
+
+	# Verify workload is functional
+	retry 10 1 crictl exec "$ctr_id" echo ok
+
+	# Cleanup
+	crictl stop "$ctr_id"
+	crictl rm "$ctr_id"
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+	# Verify pod is gone
+	run ! crictl inspectp "$pod_id"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind ci
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
- Adds a BATS test that verifies containers created with runtime_pull_image=true on the kata-remote runtime handler pull images inside the peer pod VM, not into host storage. 
- Extends the existing kata CI playbook to install the peer-pods environment (libvirt, podvm image, Cloud API Adaptor) so that kata-remote.bats runs as part of the fedora-kata Prow job.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
